### PR TITLE
Rename `ignition_ros2_control` to `ign_ros2_control`

### DIFF
--- a/launch/default.launch.py
+++ b/launch/default.launch.py
@@ -90,7 +90,7 @@ def generate_launch_description() -> LaunchDescription:
                 )
             ),
             launch_arguments=[
-                ("ros2_control_plugin", "ignition"),
+                ("ros2_control_plugin", "ign"),
                 ("ros2_control_command_interface", "effort"),
                 # TODO: Re-enable colligion geometry for manipulator arm once spawning with specific joint configuration is enabled
                 ("collision_arm", "false"),

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
   <depend>moveit_ros_planning_interface</depend>
 
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>ignition_ros2_control</exec_depend>
+  <exec_depend>ign_ros2_control</exec_depend>
   <exec_depend>pymoveit2</exec_depend>
   <exec_depend>ros_ign_bridge</exec_depend>
   <exec_depend>ros_ign_gazebo</exec_depend>


### PR DESCRIPTION
Change applied according to [ignitionrobotics/ign_ros2_control#19](https://github.com/ignitionrobotics/ign_ros2_control/pull/19).